### PR TITLE
Fix bug in ex4sample_test

### DIFF
--- a/tests4/ex4sample_test
+++ b/tests4/ex4sample_test
@@ -32,5 +32,5 @@ Node4:
 	.quad Node3
 	.int 4
 	.quad 0
-node: Node3
+node: .quad Node3
 result: .byte 0


### PR DESCRIPTION
Adding type .quad before Node3 label to fix assembler error